### PR TITLE
Fixed deprecated typedef, should not need to use the -d flag anymore

### DIFF
--- a/modules/curses.d
+++ b/modules/curses.d
@@ -40,8 +40,8 @@ extern (C):
 alias   uint mmask_t;
 alias   uint  chtype;
 alias   chtype   attr_t;
-typedef int OPTIONS;
-typedef void  SCREEN;
+alias int OPTIONS;
+alias void  SCREEN;
 __gshared struct  WINDOW
 {
   short   cury,

--- a/modules/form.d
+++ b/modules/form.d
@@ -28,9 +28,9 @@ public import ncurses, eti;
 
 extern(C):
 
-typedef void FIELD;
-typedef void FORM;
-typedef void FIELDTYPE;
+alias void FIELD;
+alias void FORM;
+alias void FIELDTYPE;
 
 /**
 Restores the cursor to the position required by the forms driver.

--- a/modules/menu.d
+++ b/modules/menu.d
@@ -27,8 +27,8 @@ public import ncurses, eti;
 
 extern(C):
 
-typedef void ITEM;
-typedef void MENU;
+alias void ITEM;
+alias void MENU;
 
 /**
 Set/get the foreground (selected) attribute of menu.

--- a/modules/panel.d
+++ b/modules/panel.d
@@ -26,7 +26,7 @@ module panel;
 public import ncurses;
 
 extern (C):
-typedef void PANEL;
+alias void PANEL;
 
 /**
 Allocates a panel structure, associates it with a window, and places


### PR DESCRIPTION
New D would not compile with typedef in place, tested with both dmd and gdc.
The solution was to simply change typedef to alias, as suggested by the compiler.
